### PR TITLE
Fixed filter_best > 0 option

### DIFF
--- a/faceanalysis.py
+++ b/faceanalysis.py
@@ -241,13 +241,15 @@ class FaceEmbedDistance:
 
         # filter out the best matches
         if filter_best > 0:
-            out = np.array(out)
-            out_eucl = np.array(out_eucl)
-            out_cos = np.array(out_cos)
-            idx = np.argsort((out_eucl + out_cos) / 2)
-            out = torch.from_numpy(out[idx][:filter_best])
-            out_eucl = out_eucl[idx][:filter_best].tolist()
-            out_cos = out_cos[idx][:filter_best].tolist()
+            out_eucl = torch.tensor(out_eucl)
+            out_cos = torch.tensor(out_cos)
+            scores = (out_eucl + out_cos) / 2
+            _, idx = torch.sort(scores)
+
+            # Select the best matches using the sorted indices
+            out = [out[i] for i in idx[:filter_best]]
+            out_eucl = out_eucl[idx][:filter_best].numpy().tolist()
+            out_cos = out_cos[idx][:filter_best].numpy().tolist()
 
         if isinstance(out, list):
             out = torch.stack(out)


### PR DESCRIPTION
When filter_best option is >0 the filtering of the best matched image/s didn't work.

A dirty fix for the error described here: https://github.com/cubiq/ComfyUI_FaceAnalysis/issues/9

@cubiq feel free to change it to your own implementation, I just did a quick thing here so I can use the feature.

After the fix:

![image](https://github.com/cubiq/ComfyUI_FaceAnalysis/assets/11049957/b2d19444-3cff-4b27-9cd8-6129e0e84ec5)
![1_](https://github.com/cubiq/ComfyUI_FaceAnalysis/assets/11049957/88acb21a-f266-4374-b9d6-25126774e595)
![2_](https://github.com/cubiq/ComfyUI_FaceAnalysis/assets/11049957/ee10dbb4-fd87-4f1f-87fc-70c29ab7cb8d)
![3_](https://github.com/cubiq/ComfyUI_FaceAnalysis/assets/11049957/c2d9d7c9-005e-4d86-a7f9-96770945b3c0)

The floats list returns:
![image](https://github.com/cubiq/ComfyUI_FaceAnalysis/assets/11049957/e6909fee-24ef-4ddc-ba46-c7b1f3887448)
