### PR TITLE
fix: Fix the iteration error when no face is detected

### DIFF
--- a/faceanalysis.py
+++ b/faceanalysis.py
@@ -127,6 +127,8 @@ class InsightFace:
         y = []
         w = []
         h = []
+        if faces is None:
+            return (img, x, y, w, h)
         for face in faces:
             x1, y1, x2, y2 = face['bbox']
             width = x2 - x1
@@ -212,6 +214,8 @@ class DLib:
         y = []
         w = []
         h = []
+        if faces is None:
+            return (img, x, y, w, h)
         for face in faces:
             x1 = max(0, face.left() - int(face.width() * padding_percent) - padding)
             y1 = max(0, face.top() - int(face.height() * padding_percent) - padding)
@@ -329,6 +333,8 @@ class FaceBoundingBox:
         for i in image:
             i = T.ToPILImage()(i.permute(2, 0, 1)).convert('RGB')
             img, x, y, w, h = analysis_models.get_bbox(i, padding, padding_percent)
+            if not img:
+                continue
             out_img.extend(img)
             out_x.extend(x)
             out_y.extend(y)


### PR DESCRIPTION
### Exception message: 
```
"'NoneType' object is not iterable","exception_type":"TypeError","traceback":["  File \"/opt/project/ComfyUI/execution.py\", line 323, in execute\n    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)\n","  File \"/opt/project/ComfyUI/execution.py\", line 198, in get_output_data\n    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)\n","  File \"/opt/project/ComfyUI/execution.py\", line 169, in _map_node_over_list\n    process_inputs(input_dict, i)\n","  File \"/opt/project/ComfyUI/execution.py\", line 158, in process_inputs\n    results.append(getattr(obj, func)(**inputs))\n","  File \"/opt/project/ComfyUI/custom_nodes/ComfyUI_FaceAnalysis/faceanalysis.py\", line 331, in bbox\n    img, x, y, w, h = analysis_models.get_bbox(i, padding, padding_percent)\n","  File \"/opt/project/ComfyUI/custom_nodes/ComfyUI_FaceAnalysis/faceanalysis.py\", line 130, in get_bbox\n    for face in faces:\n"```